### PR TITLE
Product List Auto Hero Block

### DIFF
--- a/blocks/hero/hero.css
+++ b/blocks/hero/hero.css
@@ -1,7 +1,7 @@
 main .hero-container > div {
   max-width: unset;
 }
-  
+
 main .hero-container {
   padding: 0;
 }
@@ -31,4 +31,36 @@ main .hero-container {
   object-fit: cover;
   width: 100%;
   height: 100%;
+}
+
+.productlist .hero {
+  background-color: var(--navy-blue);
+  color: white;
+  min-height: 12.5rem;
+  margin: 0;
+  padding: 0;
+}
+
+.productlist .hero h1 {
+  text-align: left;
+  margin-left: 2rem;
+  margin-top: 0;
+  font-size: var(--heading-font-size-xl);
+}
+
+.productlist .hero p {
+  position: absolute;
+  margin-left: 4vw;
+  margin-top: 2rem;
+  font-size: var(--body-font-size-xs);
+  white-space: pre-wrap;
+  line-height: 1.5rem;
+}
+
+
+@media (width >= 900px) {
+  .productlist .hero p {
+    margin-top: 3.5rem;
+    font-size: var(--body-font-size-s);
+  }
 }

--- a/scripts/scripts.js
+++ b/scripts/scripts.js
@@ -67,11 +67,12 @@ function buildHeroBlock(main) {
 function buildHeroBlockProductList(main) {
   const h1 = main.querySelector('h1');
   const picture = main.querySelector('picture');
-  const next = h1.nextElementSibling;
+  const next = h1 && h1.nextElementSibling;
+  const isNextSiblingText = next && next.tagName === 'P' && next.textContent.trim().length > 0;
   // eslint-disable-next-line no-bitwise
   if ((h1 && picture && (h1.compareDocumentPosition(picture) & Node.DOCUMENT_POSITION_PRECEDING))
-    || (h1 && next && next.tagName === 'P')) {
-    const heroBlockChildren = (next.tagName === 'P') ? [picture, h1, next] : [picture, h1];
+    || isNextSiblingText) {
+    const heroBlockChildren = isNextSiblingText ? [picture, h1, next] : [picture, h1];
     main.prepend(createElement('div', {}, buildBlock('hero', { elems: heroBlockChildren })));
   } else if (h1) {
     // Check if there are any siblings after h1, if so move them into a new section

--- a/scripts/scripts.js
+++ b/scripts/scripts.js
@@ -18,6 +18,29 @@ import {
 } from './aem.js';
 
 const LCP_BLOCKS = []; // add your LCP blocks to the list
+const PAGE_TYPE_PRODUCT = 'product';
+const PAGE_TYPE_PRODUCT_LIST = 'productlist';
+
+function getPageType() {
+  const bodyClasses = document.body.classList;
+  if (bodyClasses.contains('product')) {
+    return PAGE_TYPE_PRODUCT;
+  } if (bodyClasses.contains('productlist')) {
+    return PAGE_TYPE_PRODUCT_LIST;
+  }
+  return 'default';
+}
+
+function addBreadcrumb(main) {
+  const pageType = getPageType();
+  if (pageType !== PAGE_TYPE_PRODUCT && pageType !== PAGE_TYPE_PRODUCT_LIST) return;
+  const breadcrumbBlock = buildBlock('breadcrumb', '');
+  const breadcrumb = createElement('div', {}, breadcrumbBlock);
+  // Append before the first section
+  main.firstElementChild.before(breadcrumb);
+  decorateBlock(breadcrumbBlock);
+  loadBlock(breadcrumbBlock);
+}
 
 /**
  * Builds hero block and prepends to main in a new section.
@@ -35,6 +58,9 @@ function buildHeroBlock(main) {
     if (next) {
       const firstSection = h1.parentElement;
       const heroSection = createElement('section', { class: 'section' }, h1);
+      if (next.tagName === 'P' && getPageType() === PAGE_TYPE_PRODUCT_LIST) {
+        heroSection.append(next);
+      }
       firstSection.parentElement.prepend(heroSection);
     }
     h1.parentElement.classList.add('plain-hero');
@@ -99,15 +125,8 @@ async function applyTemplateDefaultContent(main) {
     main.firstElementChild.after(leftRail);
     decorateBlock(leftRailBlock);
     loadBlock(leftRailBlock);
-
-    // ---- Add breadcrumb
-    const breadcrumbBlock = buildBlock('breadcrumb', '');
-    const breadcrumb = createElement('div', {}, breadcrumbBlock);
-    // Append before the first section
-    main.firstElementChild.before(breadcrumb);
-    decorateBlock(breadcrumbBlock);
-    loadBlock(breadcrumbBlock);
   }
+  addBreadcrumb(main);
 }
 
 /**

--- a/scripts/scripts.js
+++ b/scripts/scripts.js
@@ -58,9 +58,26 @@ function buildHeroBlock(main) {
     if (next) {
       const firstSection = h1.parentElement;
       const heroSection = createElement('section', { class: 'section' }, h1);
-      if (next.tagName === 'P' && getPageType() === PAGE_TYPE_PRODUCT_LIST) {
-        heroSection.append(next);
-      }
+      firstSection.parentElement.prepend(heroSection);
+    }
+    h1.parentElement.classList.add('plain-hero');
+  }
+}
+
+function buildHeroBlockProductList(main) {
+  const h1 = main.querySelector('h1');
+  const picture = main.querySelector('picture');
+  const next = h1.nextElementSibling;
+  // eslint-disable-next-line no-bitwise
+  if ((h1 && picture && (h1.compareDocumentPosition(picture) & Node.DOCUMENT_POSITION_PRECEDING))
+    || (h1 && next && next.tagName === 'P')) {
+    const heroBlockChildren = (next.tagName === 'P') ? [picture, h1, next] : [picture, h1];
+    main.prepend(createElement('div', {}, buildBlock('hero', { elems: heroBlockChildren })));
+  } else if (h1) {
+    // Check if there are any siblings after h1, if so move them into a new section
+    if (next) {
+      const firstSection = h1.parentElement;
+      const heroSection = createElement('section', { class: 'section' }, h1);
       firstSection.parentElement.prepend(heroSection);
     }
     h1.parentElement.classList.add('plain-hero');
@@ -85,7 +102,12 @@ async function loadFonts() {
  */
 function buildAutoBlocks(main) {
   try {
-    buildHeroBlock(main);
+    const pageType = getPageType();
+    if (pageType === PAGE_TYPE_PRODUCT_LIST) {
+      buildHeroBlockProductList(main);
+    } else {
+      buildHeroBlock(main);
+    }
   } catch (error) {
     // eslint-disable-next-line no-console
     console.error('Auto Blocking failed', error);

--- a/styles/styles.css
+++ b/styles/styles.css
@@ -204,13 +204,13 @@ a.button.secondary, button.secondary {
 }
 
 .navy a.button.secondary, .dark a.button.secondary,
-.navy button.secondar, .dark button.secondary {  
+.navy button.secondar, .dark button.secondary {
   border-color: var(--background-color);
   color: var(--background-color);
 }
 
 .navy a.button.secondary:hover, .dark a.button.secondary:hover,
-.navy button.secondary:hover, .dark button.secondary:hover {  
+.navy button.secondary:hover, .dark button.secondary:hover {
   filter: none;
   border-color: rgb(255 255 255 / 60%)
 }
@@ -282,7 +282,27 @@ main .section.navy, .section.plain-hero {
   padding-top: 0.25em;
 }
 
-.section.plain-hero h1::after {
+.productlist .section.plain-hero {
+  min-height: 12rem;
+}
+
+.productlist .section.plain-hero h1 {
+  text-align: left;
+  margin-left: 2rem;
+  padding-bottom: 0;
+  font-size: var(--heading-font-size-xl);
+  white-space: pre-wrap;
+}
+
+.productlist .section.plain-hero p {
+  position: absolute;
+  margin-left: 4vw;
+  font-size: var(--body-font-size-xs);
+  white-space: pre-wrap;
+  line-height: 1.5rem;
+}
+
+.product .section.plain-hero h1::after {
   content: " ";
   display: block;
   width: 1.5em;
@@ -290,4 +310,20 @@ main .section.navy, .section.plain-hero {
   margin: auto;
   margin-top: 0.25em;
   background-color: var(--orange);
+}
+
+@media (width >= 900px) {
+  .productlist .section.plain-hero {
+    min-height: 10rem;
+  }
+
+  .productlist .section.plain-hero h1 {
+    padding-top: 1rem;
+  }
+}
+
+@media (width < 450px) {
+  .productlist .section.plain-hero h1 {
+    font-size: var(--heading-font-size-l);
+  }
 }

--- a/styles/styles.css
+++ b/styles/styles.css
@@ -282,27 +282,7 @@ main .section.navy, .section.plain-hero {
   padding-top: 0.25em;
 }
 
-.productlist .section.plain-hero {
-  min-height: 12rem;
-}
-
-.productlist .section.plain-hero h1 {
-  text-align: left;
-  margin-left: 2rem;
-  padding-bottom: 0;
-  font-size: var(--heading-font-size-xl);
-  white-space: pre-wrap;
-}
-
-.productlist .section.plain-hero p {
-  position: absolute;
-  margin-left: 4vw;
-  font-size: var(--body-font-size-xs);
-  white-space: pre-wrap;
-  line-height: 1.5rem;
-}
-
-.product .section.plain-hero h1::after {
+.section.plain-hero h1::after {
   content: " ";
   display: block;
   width: 1.5em;
@@ -310,20 +290,4 @@ main .section.navy, .section.plain-hero {
   margin: auto;
   margin-top: 0.25em;
   background-color: var(--orange);
-}
-
-@media (width >= 900px) {
-  .productlist .section.plain-hero {
-    min-height: 10rem;
-  }
-
-  .productlist .section.plain-hero h1 {
-    padding-top: 1rem;
-  }
-}
-
-@media (width < 450px) {
-  .productlist .section.plain-hero h1 {
-    font-size: var(--heading-font-size-l);
-  }
 }


### PR DESCRIPTION
- Created a new method `buildHeroBlockProductList` for auto-blocking hero block in product list page, allowing future modification simpler.
- Momentive Hero Block on ProductList has a heading and associated text. So, if `<h1>` has a next sibbling as `<p>` with text content it will be auto-blocked.
- The auto-block logic used in product hero block is also intact i.e, picture and plain-hero will work here as it is.
- encapsulated breadcrumb logic in method `addBreadcrumb` which checks page type and then add breadcrumb, it is same for product and productList page

Please always provide the [GitHub issue(s)](../issues) your PR is for, as well as test URLs where your change can be observed (before and after):

Fix #19 

Test URLs:
- Before: https://main--momentive--aemsites.hlx.page/drafts/anuj/en-us/categories/encapsulants/conformalcoatings/products
- After: https://issue-19--momentive--aemsites.hlx.page/drafts/anuj/en-us/categories/encapsulants/conformalcoatings/products
